### PR TITLE
fix(node-status): Now When user added New node in the cluster , cluster-service will able to get the Dynamic resource of the node

### DIFF
--- a/cluster-service/README.md
+++ b/cluster-service/README.md
@@ -13,6 +13,28 @@ Before getting started, ensure the following tools are installed and configured:
 - **Uvicorn**: ASGI server to run the FastAPI app
 - **Message Broker**: (e.g., RabbitMQ, Kafka) for pub/sub functionality
 
+### **Set Up a Virtual Environment**
+
+1. Create a virtual environment:
+   ```bash
+   python3 -m venv venv
+   ```
+
+2. Activate the virtual environment:
+   - On Linux/macOS:
+     ```bash
+     source venv/bin/activate
+     ```
+   - On Windows:
+     ```bash
+     .\venv\Scripts\activate
+     ```
+
+3. Once activated, install the required dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
 ---
 
 ## 🚀 **Getting Started**

--- a/cluster-status/main.go
+++ b/cluster-status/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -89,6 +90,7 @@ func (c *Controller) syncToStdout(key string) error {
 							case "ContainerConfigError":
 							case "CrashLoopBackOff":
 								statusString = waitingReason
+								break
 							default:
 								statusString = "Pending"
 							}
@@ -169,23 +171,24 @@ func main() {
 	if err != nil {
 		panic(err.Error())
 	}
-
 	// creates the clientset
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		panic(err.Error())
 	}
-
+	if err != nil {
+		klog.Fatal(err)
+	}
 	// create the pod watcher
 	podListWatcher := cache.NewListWatchFromClient(clientset.CoreV1().RESTClient(), "pods", v1.NamespaceAll, fields.Everything())
-
-	// create the node watcher
-	nodeListWatcher := cache.NewListWatchFromClient(clientset.CoreV1().RESTClient(), "nodes", v1.NamespaceAll, fields.Everything())
 
 	// create the workqueue
 	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
 
-	// Bind the workqueue to a cache with the help of an informer for Pods
+	// Bind the workqueue to a cache with the help of an informer. This way we make sure that
+	// whenever the cache is updated, the pod key is added to the workqueue.
+	// Note that when we finally process the item from the workqueue, we might see a newer version
+	// of the Pod than the version which was responsible for triggering the update.
 	indexer, informer := cache.NewIndexerInformer(podListWatcher, &v1.Pod{}, 0, cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			key, err := cache.MetaNamespaceKeyFunc(obj)
@@ -200,6 +203,8 @@ func main() {
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
+			// IndexerInformer uses a delta queue, therefore for deletes we have to use this
+			// key function.
 			key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 			if err == nil {
 				queue.Add(key)
@@ -207,56 +212,33 @@ func main() {
 		},
 	}, cache.Indexers{})
 
-	// Bind the workqueue to a cache with the help of an informer for Nodes
-	_, nodeInformer := cache.NewIndexerInformer(nodeListWatcher, &v1.Node{}, 0, cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			node := obj.(*v1.Node)
-			fmt.Printf("Node Added: %s, Status: %s\n", node.Name, getNodeCondition(node))
-		},
-		UpdateFunc: func(old interface{}, new interface{}) {
-			node := new.(*v1.Node)
-			fmt.Printf("Node Updated: %s, Status: %s\n", node.Name, getNodeCondition(node))
-		},
-		DeleteFunc: func(obj interface{}) {
-			node := obj.(*v1.Node)
-			fmt.Printf("Node Deleted: %s\n", node.Name)
-		},
-	}, cache.Indexers{})
-
-	// Start the Pod controller
 	controller := NewController(queue, indexer, informer)
 
-	// Start the Node informer
+	// We can now warm up the cache for initial synchronization.
+	// Let's suppose that we knew about a pod "mypod" on our last run, therefore add it to the cache.
+	// If this pod is not there anymore, the controller will be notified about the removal after the
+	// cache has synchronized.
+	indexer.Add(&v1.Pod{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      "mypod",
+			Namespace: v1.NamespaceDefault,
+		},
+	})
+
+	// Now let's start the controller
 	stop := make(chan struct{})
 	defer close(stop)
-	go nodeInformer.Run(stop)
-
-	// Start the Pod controller
 	go controller.Run(1, stop)
 
 	// Wait forever
 	select {}
 }
 
-// Helper function to get the Node condition
-func getNodeCondition(node *v1.Node) string {
-	for _, condition := range node.Status.Conditions {
-		if condition.Type == v1.NodeReady {
-			if condition.Status == v1.ConditionTrue {
-				return "Ready"
-			}
-			return "NotReady"
-		}
-	}
-	return "Unknown"
-}
-
 func patchClusterStatus(name, id, status string) error {
 	if os.Getenv("LOCAL") == "true" {
 		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	}
-	// url := os.Getenv("API_URL") + "/v1/public/cluster-status?token=" + os.Getenv("API_TOKEN")
-	url := "https://webhook.site/e5f0b4f7-3c84-43c7-b56f-a27cd4641162"
+	url := os.Getenv("API_URL") + "/v1/public/cluster-status?token=" + os.Getenv("API_TOKEN")
 	if url == "" {
 		logrus.Error("base url is not set")
 		return errors.New("base url is not set")
@@ -265,7 +247,6 @@ func patchClusterStatus(name, id, status string) error {
 		"name":   name,
 		"id":     id,
 		"status": status,
-		"Node":   "Node1",
 	}
 	logrus.Info("payload for patch request :: ", payload)
 
@@ -290,7 +271,7 @@ func patchClusterStatus(name, id, status string) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("request failed with status code: %d", resp.StatusCode)
+		return fmt.Errorf("Request failed with status code: %d", resp.StatusCode)
 	}
 	logrus.Info("Request successful")
 	return nil


### PR DESCRIPTION
**Description:**  
As a developer, I couldn't find the newly added node resource in  `cluster-service` until restarting the services. This prevents cluster creation as the newly added node information is not available.  

### **Acceptance Criteria:**  
- Debug the issue to identify the root cause.  
- Resolve the issue so that newly added nodes are detected without requiring a restart of  `cluster-service`.  

### **Steps to Reproduce:**  
1. Add a new node to the Worker cluster.  
2. Attempt to create a cluster.  
3. The cluster creation fails because the newly added node is not recognized.  

### **Expected Behavior:**  
- Newly added nodes should be detected automatically without requiring a restart of  `cluster-service`.  

### **Additional Information:**  
- Logs from`cluster-service` after adding a new node.  
- Possible cache refresh issues or event listener failures.


